### PR TITLE
Fix/errors-on-list_account_aliases

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -152,13 +152,16 @@ func (amz *AWS) resolveAlias(ctx context.Context, role *Role) (*Role, error) {
 		ListAccountAliases(ctx, &iam.ListAccountAliasesInput{})
 
 	if err != nil {
-		return nil, err
+		logger.Debug().Err(err).Msg("ListAccountAliases failed, fallback to account ID")
+		role.AccountAlias = role.AccountID()
 	} else if len(out.AccountAliases) == 0 {
-		return nil, fmt.Errorf("no account alias found")
+		logger.Debug().Msg("no account alias found, fallback to account ID")
+		role.AccountAlias = role.AccountID()
 	} else {
 		role.AccountAlias = out.AccountAliases[0]
-		return role, err
 	}
+
+	return role, nil
 }
 
 func (amz *AWS) ResolveAliases(ctx context.Context) ([]*Role, error) {


### PR DESCRIPTION
## 契機

`ListAccountAliases` の権限のないロールが SAML レスポンスに含まれる場合に、 `-l` オプションの実行に失敗することが報告されました。

https://akerun.slack.com/archives/C06S0UNV8/p1718006596857919?thread_ts=1716434302.453929&cid=C06S0UNV8

## 概要

`aws-google-auth` の挙動に合わせて、エラーは握り潰すようにしました。

https://github.com/cevoaustralia/aws-google-auth/blob/master/aws_google_auth/amazon.py#L134-L142

## テスト

- @ishiiturk -san の環境で、 `-l` オプション実行時にエラーとならないこと
- @daikw の環境で、 `-l` オプション実行時にエラーとならないこと