### PR TITLE
Feat/browser-timeout-and-others

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run tests
         run: make test
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.55.2
           args: ./...

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --profile value, -p value                           AWS Profile to use (default: "akerun")
-   --duration-seconds value, -d value                  Session Duration (in seconds) (default: 3600)
-   --sp-id value, -s value                             Service Provider ID (default value is in /Users/daikiwatanabe/.aws/config)
-   --idp-id value, -i value                            Identity Provider ID (default value is in /Users/daikiwatanabe/.aws/config)
-   --role-arn value, -r value                          AWS Role Arn for assuming to, ex: arn:aws:iam::123456789012:role/role-name
-   --select-role-interactivelly role-arn, -l role-arn  choose AWS Role interactively. If set, role-arn will be ignored (default: false)
-   --browser-timeout value, -t value                   browser timeout duration in seconds (default: 60)
-   --log value                                         change Log level, choose from: [trace | debug | info | warn | error | fatal | panic]
-   --help, -h                                          show help (default: false)
+   --profile value, -p value           AWS Profile to use (default: "akerun")
+   --duration-seconds value, -d value  Session Duration (in seconds) (default: 3600)
+   --sp-id value, -s value             Service Provider ID (default value is in /Users/daikiwatanabe/.aws/config)
+   --idp-id value, -i value            Identity Provider ID (default value is in /Users/daikiwatanabe/.aws/config)
+   --role-arn value, -r value          AWS Role Arn for assuming to, ex: arn:aws:iam::123456789012:role/role-name
+   --select-role-interactivelly, -l    choose AWS Role interactively. If set, 'role-arn' will be ignored (default: false)
+   --browser-timeout value, -t value   browser timeout duration in seconds (default: 60)
+   --log value                         change Log level, choose from: [trace | debug | info | warn | error | fatal | panic]
+   --help, -h                          show help (default: false)
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ USAGE:
    aws-google-login [global options] [command [command options]] [arguments...]
 
 COMMANDS:
+   config   Show current configuration
+   cache    Manage application's cache
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # aws-google-login
 
-This command-line tool allows you to acquire AWS temporary (STS) credentials using Google Apps as a federated (Single Sign-On, or SSO) provider. This project was inspired from [aws-google-auth](https://github.com/cevoaustralia/aws-google-auth)
- and the help of [playwright-go](https://github.com/mxschmitt/playwright-go) for the interactive Graphic User Interface (GUI)
+This command-line tool allows you to acquire AWS temporary (STS) credentials using Google Apps as a federated (Single Sign-On, or SSO) provider. This project was inspired from [aws-google-auth](https://github.com/cevoaustralia/aws-google-auth) and the help of [playwright-go](https://github.com/mxschmitt/playwright-go) for the interactive Graphic User Interface (GUI).
+
+This was hard-forked from [cucxabong/aws-google-login](https://github.com/cucxabong/aws-google-login).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ GLOBAL OPTIONS:
    --idp-id value, -i value                            Identity Provider ID (default value is in /Users/daikiwatanabe/.aws/config)
    --role-arn value, -r value                          AWS Role Arn for assuming to, ex: arn:aws:iam::123456789012:role/role-name
    --select-role-interactivelly role-arn, -l role-arn  choose AWS Role interactively. If set, role-arn will be ignored (default: false)
+   --browser-timeout value, -t value                   browser timeout duration in seconds (default: 60)
    --log value                                         change Log level, choose from: [trace | debug | info | warn | error | fatal | panic]
    --help, -h                                          show help (default: false)
-   ```
+```

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -35,7 +35,7 @@ func handleMain(ctx context.Context, c *cli.Command) (err error) {
 
 	authnRequest, err := g.Login(&awslogin.LoginOptions{
 		Verbose:        zerolog.GlobalLevel() < zerolog.WarnLevel,
-		BrowserTimeout: c.Float("browser-timeout"),
+		BrowserTimeout: c.Int("browser-timeout"),
 	})
 	if err != nil {
 		return err

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -84,3 +84,20 @@ func handleMain(ctx context.Context, c *cli.Command) (err error) {
 	fmt.Println("Temporary AWS credentials have been saved to", awslogin.AWSCredPath())
 	return nil
 }
+
+func handleConfig(ctx context.Context, c *cli.Command) error {
+	if c.Bool("config_path") {
+		fmt.Println(awslogin.AWSConfigPath())
+	}
+	if c.Bool("credentials_path") {
+		fmt.Println(awslogin.AWSCredPath())
+	}
+
+	cfg, err := awslogin.LoadConfig(awslogin.AWSConfigPath(), c.String("profile"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%+v\n", cfg)
+	return nil
+}

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	awslogin "github.com/Photosynth-inc/aws-google-login"
+	"github.com/manifoldco/promptui"
+	"github.com/rs/zerolog"
+	"github.com/urfave/cli/v3"
+)
+
+func handleMain(ctx context.Context, c *cli.Command) (err error) {
+	g, err := awslogin.LoadConfig(awslogin.AWSConfigPath(), c.String("profile"))
+	if err != nil {
+		return err
+	}
+
+	// Override the configuration if the flags are set
+	{
+		if c.String("sp-id") != "" {
+			g.Google.GoogleSPID = c.String("sp-id")
+		}
+		if c.String("idp-id") != "" {
+			g.Google.GoogleIDPID = c.String("idp-id")
+		}
+		if c.String("role-arn") != "" {
+			g.Google.RoleARN = c.String("role-arn")
+		}
+		if c.Int("duration-seconds") != 0 {
+			g.Google.Duration = c.Int("duration-seconds")
+		}
+	}
+
+	authnRequest, err := g.Login(&awslogin.LoginOptions{
+		Verbose:        zerolog.GlobalLevel() < zerolog.WarnLevel,
+		BrowserTimeout: c.Float("browser-timeout"),
+	})
+	if err != nil {
+		return err
+	}
+
+	amz, err := awslogin.NewAWSConfig(authnRequest, g)
+	if err != nil {
+		return err
+	}
+
+	var role *awslogin.Role
+	if c.Bool("select-role-interactivelly") {
+		roles, err := amz.ResolveAliases(ctx)
+		if err != nil {
+			return err
+		}
+		prompt := promptui.Select{
+			Label: "Select AWS Role",
+			Items: roles,
+			Size:  10,
+		}
+		index, _, err := prompt.Run()
+		if err != nil {
+			return fmt.Errorf("prompt failed %v", err)
+		}
+		role = roles[index]
+	} else {
+		role, err = amz.ResolveRole(g.Google.RoleARN)
+		if err != nil {
+			return err
+		}
+	}
+
+	creds, err := amz.AssumeRole(ctx, role)
+	if err != nil {
+		return err
+	}
+
+	awsCreds := &awslogin.AWSCredentials{
+		Profile:     g.Profile,
+		Credentials: creds,
+	}
+
+	if err := awsCreds.SaveTo(awslogin.AWSCredPath()); err != nil {
+		return err
+	}
+	fmt.Println("Temporary AWS credentials have been saved to", awslogin.AWSCredPath())
+	return nil
+}

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	awslogin "github.com/Photosynth-inc/aws-google-login"
 	"github.com/manifoldco/promptui"
@@ -106,6 +107,14 @@ func handleConfig(ctx context.Context, c *cli.Command) error {
 
 func handleCache(ctx context.Context, c *cli.Command) error {
 	if c.Bool("clear") {
+		fmt.Printf("Are you sure to clear cache? [y/N] ")
+		var ans string
+		fmt.Fscanln(os.Stdin, &ans)
+		if ans != "y" {
+			fmt.Println("Aborted")
+			return nil
+		}
+
 		if err := awslogin.DeleteBrowserCache(); err != nil {
 			return err
 		}

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -101,3 +101,14 @@ func handleConfig(ctx context.Context, c *cli.Command) error {
 	fmt.Printf("%+v\n", cfg)
 	return nil
 }
+
+func handleCache(ctx context.Context, c *cli.Command) error {
+	if c.Bool("clear") {
+		if err := awslogin.DeleteBrowserCache(); err != nil {
+			return err
+		}
+		fmt.Println("Cache has been cleared")
+	}
+	fmt.Println(awslogin.ConfigDirRoot())
+	return nil
+}

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -88,9 +88,11 @@ func handleMain(ctx context.Context, c *cli.Command) (err error) {
 func handleConfig(ctx context.Context, c *cli.Command) error {
 	if c.Bool("config_path") {
 		fmt.Println(awslogin.AWSConfigPath())
+		return nil
 	}
 	if c.Bool("credentials_path") {
 		fmt.Println(awslogin.AWSCredPath())
+		return nil
 	}
 
 	cfg, err := awslogin.LoadConfig(awslogin.AWSConfigPath(), c.String("profile"))
@@ -108,7 +110,9 @@ func handleCache(ctx context.Context, c *cli.Command) error {
 			return err
 		}
 		fmt.Println("Cache has been cleared")
+		return nil
 	}
+
 	fmt.Println(awslogin.ConfigDirRoot())
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,91 +6,15 @@ import (
 	"os"
 
 	awslogin "github.com/Photosynth-inc/aws-google-login"
-	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v3"
 )
-
-func handler(ctx context.Context, c *cli.Command) (err error) {
-	g, err := awslogin.LoadConfig(awslogin.AWSConfigPath(), c.String("profile"))
-	if err != nil {
-		return err
-	}
-
-	// Override the configuration if the flags are set
-	{
-		if c.String("sp-id") != "" {
-			g.Google.GoogleSPID = c.String("sp-id")
-		}
-		if c.String("idp-id") != "" {
-			g.Google.GoogleIDPID = c.String("idp-id")
-		}
-		if c.String("role-arn") != "" {
-			g.Google.RoleARN = c.String("role-arn")
-		}
-		if c.Int("duration-seconds") != 0 {
-			g.Google.Duration = c.Int("duration-seconds")
-		}
-	}
-
-	authnRequest, err := g.Login(&awslogin.LoginOptions{
-		Verbose:        zerolog.GlobalLevel() < zerolog.WarnLevel,
-		BrowserTimeout: c.Float("browser-timeout"),
-	})
-	if err != nil {
-		return err
-	}
-
-	amz, err := awslogin.NewAWSConfig(authnRequest, g)
-	if err != nil {
-		return err
-	}
-
-	var role *awslogin.Role
-	if c.Bool("select-role-interactivelly") {
-		roles, err := amz.ResolveAliases(ctx)
-		if err != nil {
-			return err
-		}
-		prompt := promptui.Select{
-			Label: "Select AWS Role",
-			Items: roles,
-			Size:  10,
-		}
-		index, _, err := prompt.Run()
-		if err != nil {
-			return fmt.Errorf("prompt failed %v", err)
-		}
-		role = roles[index]
-	} else {
-		role, err = amz.ResolveRole(g.Google.RoleARN)
-		if err != nil {
-			return err
-		}
-	}
-
-	creds, err := amz.AssumeRole(ctx, role)
-	if err != nil {
-		return err
-	}
-
-	awsCreds := &awslogin.AWSCredentials{
-		Profile:     g.Profile,
-		Credentials: creds,
-	}
-
-	if err := awsCreds.SaveTo(awslogin.AWSCredPath()); err != nil {
-		return err
-	}
-	fmt.Println("Temporary AWS credentials have been saved to", awslogin.AWSCredPath())
-	return nil
-}
 
 func main() {
 	app := &cli.Command{
 		Name:   "aws-google-login",
 		Usage:  "Acquire temporary AWS credentials via Google SSO (SAML v2)",
-		Action: handler,
+		Action: handleMain,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "profile",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,7 +122,7 @@ func main() {
 			&cli.BoolFlag{
 				Name:    "select-role-interactivelly",
 				Aliases: []string{"l"},
-				Usage:   "choose AWS Role interactively. If set, `role-arn` will be ignored",
+				Usage:   "choose AWS Role interactively. If set, 'role-arn' will be ignored",
 				Value:   false,
 			},
 			&cli.FloatFlag{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,11 +49,11 @@ func main() {
 				Usage:   "choose AWS Role interactively. If set, 'role-arn' will be ignored",
 				Value:   false,
 			},
-			&cli.FloatFlag{
+			&cli.IntFlag{
 				Name:    "browser-timeout",
 				Aliases: []string{"t"},
 				Usage:   "browser timeout duration in seconds",
-				Value:   60.0,
+				Value:   60,
 			},
 			&cli.StringFlag{
 				Name:       "log",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,8 @@ func handler(ctx context.Context, c *cli.Command) (err error) {
 	}
 
 	authnRequest, err := g.Login(&awslogin.LoginOptions{
-		Verbose: zerolog.GlobalLevel() < zerolog.WarnLevel,
+		Verbose:        zerolog.GlobalLevel() < zerolog.WarnLevel,
+		BrowserTimeout: c.Float("browser-timeout"),
 	})
 	if err != nil {
 		return err
@@ -123,6 +124,12 @@ func main() {
 				Aliases: []string{"l"},
 				Usage:   "choose AWS Role interactively. If set, `role-arn` will be ignored",
 				Value:   false,
+			},
+			&cli.FloatFlag{
+				Name:    "browser-timeout",
+				Aliases: []string{"t"},
+				Usage:   "browser timeout duration in seconds",
+				Value:   60.0,
 			},
 			&cli.StringFlag{
 				Name:       "log",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,6 +85,17 @@ func main() {
 					},
 				},
 			},
+			{
+				Name:   "cache",
+				Usage:  "Manage application's cache",
+				Action: handleCache,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "clear",
+						Usage: "Clear the browser cache (this is not reversible!)",
+					},
+				},
+			},
 		},
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,23 @@ func main() {
 				},
 			},
 		},
+		Commands: []*cli.Command{
+			{
+				Name:   "config",
+				Usage:  "Show current configuration",
+				Action: handleConfig,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "config_path",
+						Usage: "Show the aws configuration path",
+					},
+					&cli.BoolFlag{
+						Name:  "credentials_path",
+						Usage: "Show the aws credentials path",
+					},
+				},
+			},
+		},
 	}
 
 	// set default / weirdly --log flag does not work if not set

--- a/configuration.go
+++ b/configuration.go
@@ -1,6 +1,8 @@
 package awslogin
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"gopkg.in/ini.v1"
 )
@@ -10,6 +12,23 @@ type AWSConfig struct {
 	Profile string
 	Region  string
 	Google  AWSConfig_GoogleConfig
+}
+
+func (c *AWSConfig) String() string {
+	return fmt.Sprintf(
+		"Profile: %s\nRegion: %s\nGoogle_Configuration:\n  Ask_Role: %v\n  Keyring: %v\n  Duration: %d\n  Google_IDP_ID: %s\n  Google_SP_ID: %s\n  U2F_Disabled: %v\n  Google_Username: %s\n  BG_Response: %s\n  Role_ARN: %s",
+		c.Profile,
+		c.Region,
+		c.Google.AskRole,
+		c.Google.Keyring,
+		c.Google.Duration,
+		c.Google.GoogleIDPID,
+		c.Google.GoogleSPID,
+		c.Google.U2FDisabled,
+		c.Google.GoogleUserName,
+		c.Google.BGResponse,
+		c.Google.RoleARN,
+	)
 }
 
 type AWSConfig_GoogleConfig struct {

--- a/google.go
+++ b/google.go
@@ -17,7 +17,8 @@ func (cfg *AWSConfig) WaitURL() string {
 }
 
 type LoginOptions struct {
-	Verbose bool
+	Verbose        bool
+	BrowserTimeout float64
 }
 
 // Login invokes the Playwright browser to login to Google,
@@ -39,6 +40,7 @@ func (cfg *AWSConfig) Login(opt *LoginOptions) (resp string, err error) {
 
 	browser, err := pw.Chromium.LaunchPersistentContext(ConfigEntry("browser"), playwright.BrowserTypeLaunchPersistentContextOptions{
 		Headless: playwright.Bool(false),
+		Timeout:  playwright.Float(opt.BrowserTimeout),
 	})
 	if err != nil {
 		return "", fmt.Errorf("could not launch a browser %v", err)

--- a/google.go
+++ b/google.go
@@ -18,7 +18,7 @@ func (cfg *AWSConfig) WaitURL() string {
 
 type LoginOptions struct {
 	Verbose        bool
-	BrowserTimeout float64
+	BrowserTimeout int64 // in seconds
 }
 
 // Login invokes the Playwright browser to login to Google,
@@ -40,8 +40,9 @@ func (cfg *AWSConfig) Login(opt *LoginOptions) (resp string, err error) {
 
 	browser, err := pw.Chromium.LaunchPersistentContext(ConfigEntry("browser"), playwright.BrowserTypeLaunchPersistentContextOptions{
 		Headless: playwright.Bool(false),
-		Timeout:  playwright.Float(opt.BrowserTimeout),
 	})
+	browser.SetDefaultTimeout(1000.0 * float64(opt.BrowserTimeout))
+
 	if err != nil {
 		return "", fmt.Errorf("could not launch a browser %v", err)
 	}

--- a/google.go
+++ b/google.go
@@ -41,7 +41,9 @@ func (cfg *AWSConfig) Login(opt *LoginOptions) (resp string, err error) {
 	browser, err := pw.Chromium.LaunchPersistentContext(ConfigEntry("browser"), playwright.BrowserTypeLaunchPersistentContextOptions{
 		Headless: playwright.Bool(false),
 	})
+
 	browser.SetDefaultTimeout(1000.0 * float64(opt.BrowserTimeout))
+	browser.SetDefaultNavigationTimeout(1000.0 * float64(opt.BrowserTimeout))
 
 	if err != nil {
 		return "", fmt.Errorf("could not launch a browser %v", err)

--- a/utils.go
+++ b/utils.go
@@ -65,6 +65,10 @@ func ConfigEntry(name string) string {
 	return filepath.Join(ConfigDirRoot(), name)
 }
 
+func DeleteBrowserCache() error {
+	return os.RemoveAll(ConfigEntry("browser"))
+}
+
 func AWSConfigPath() string {
 	return filepath.Join(must(os.UserHomeDir()), ".aws/config")
 }


### PR DESCRIPTION
close: #5 

## 概要

- ちょこちょこと README などを修正しつつ、
- #5 の通り、デフォルトのタイムアウトを 60 秒にしてオプションでも指定できるようにした上で、
- サブコマンドを2つ追加しました
    - `config`: 設定ファイルのパスか、設定情報を表示するようにしました
    - `cache`: ブラウザキャッシュがデフォルトブラウザ以外でも永続化されてしまうため、キャッシュの場所とその削除手段を提供しました

## テスト

### `-t 1` でタイムアウトすること

```sh
❯ ./aws-google-login -l -t 1
Please login to your Google account in the browser...
could not goto: Frame.Goto https://accounts.google.com/o/saml2/initsso?idpid=C02g4b4os&spid=445547042005&forceauthn=false: playwright: timeout: Timeout 1000ms exceeded.
```

### `config` サブコマンドの挙動が妥当そうなこと

```sh
aws-google-login on  feat/browser-timeout via 🐹 on ☁️  daikw@yak-shaver.com(asia-northeast1) took 33s 
❯ ./aws-google-login config | head
Profile: akerun
Region: ap-northeast-1
Google_Configuration:
  Ask_Role: true
  Keyring: false
  Duration: 3600
```

### `cache --clear` の実行後に、ブラウザでログイン要求されること

```sh
aws-google-login on  feat/browser-timeout via 🐹 on ☁️  daikw@yak-shaver.com(asia-northeast1) took 2s 
❯ ./aws-google-login cache --clear
Are you sure to clear cache? [y/N] y
Cache has been cleared

aws-google-login on  feat/browser-timeout via 🐹 v1.21.6 on ☁️  daikw@yak-shaver.com(asia-northeast1) took 4s 
❯ ./aws-google-login -l
Please login to your Google account in the browser...
could not wait for URL: timeout:Timeout 30000.00ms exceeded.
```