### PR TITLE
Bug/misc

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ before:
     - go generate ./...
 
 builds:
-  - main: ./cmd/main.go
+  - main: ./cmd
     env:
       - CGO_ENABLED=0
     goos:

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,6 @@ lint:
 build:
 	go build $(VERBOSE_FLAG) -ldflags=$(BUILD_LDFLAGS) -o $(EXECUTABLE) cmd/*
 
-DIST_DIR = dist
-.PHONY: cross
-cross:
-	GOOS=linux  GOARCH=arm   go build --tags release -ldflags=$(BUILD_LDFLAGS) -trimpath -o ../$(DIST_DIR)/$(EXECUTABLE).linux.arm cmd/*
-	GOOS=linux  GOARCH=amd64 go build --tags release -ldflags=$(BUILD_LDFLAGS) -trimpath -o ../$(DIST_DIR)/$(EXECUTABLE).linux.amd64 cmd/*
-	GOOS=linux  GOARCH=arm64 go build --tags release -ldflags=$(BUILD_LDFLAGS) -trimpath -o ../$(DIST_DIR)/$(EXECUTABLE).linux.arm64 cmd/*
-	GOOS=darwin GOARCH=amd64 go build --tags release -ldflags=$(BUILD_LDFLAGS) -trimpath -o ../$(DIST_DIR)/$(EXECUTABLE).darwin.amd64 cmd/*
-	GOOS=darwin GOARCH=arm64 go build --tags release -ldflags=$(BUILD_LDFLAGS) -trimpath -o ../$(DIST_DIR)/$(EXECUTABLE).darwin.arm64 cmd/*
+.PHONY: goreleaser
+goreleaser:
+	goreleaser release --snapshot --clean


### PR DESCRIPTION
## 概要

goreleaser のビルド対象が古くなっていたので修正しました


## テスト

`make goreleaser` が正常終了すること

```sh
aws-google-login on  bug/misc via 🐹 on ☁️  daikw@yak-shaver.com(asia-northeast1) took 3s 
❯ make goreleaser
goreleaser release --snapshot --clean
  • starting release...
  • loading                                          path=.goreleaser.yaml
  • skipping announce, publish and validate...
  • loading environment variables
 
...

  • release succeeded after 5s
  • thanks for using goreleaser!
```
